### PR TITLE
Fixes class not found error in REST API (FREEPBX-20521)

### DIFF
--- a/Api/Rest/Daynight.php
+++ b/Api/Rest/Daynight.php
@@ -42,7 +42,7 @@ class Daynight extends Base {
 		$app->put('/{id}', function ($request, $response, $args) {
 			\FreePBX::Modules()->loadFunctionsInc('daynight');
 			$params = $request->getParsedBody();
-			$dn = new dayNightObject($args['id']);
+			$dn = new \dayNightObject($args['id']);
 
 			if ($dn) {
 				$dn->setState($params['state']);


### PR DESCRIPTION
Fixes an issue where the PUT request in the REST API failed as detailed in the following issue: https://issues.freepbx.org/browse/FREEPBX-20521